### PR TITLE
Parallelize reads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,9 @@ libraryDependencies ++= Seq(
   "org.ojai" % "ojai" % "3.0-mapr-1808",
   "org.ojai" % "ojai-scala" % "3.0-mapr-1808",
   
-  "com.mapr.db" % "maprdb-spark" % "2.3.1-mapr-1808" % "provided"
+  "com.mapr.db" % "maprdb-spark" % "2.3.1-mapr-1808" % "provided",
+  "com.mapr.db" % "maprdb" % "6.1.0-mapr" % "provided",
+  "xerces" % "xercesImpl" % "2.11.0" % "provided" //Needs to be manually added since there is a reference to SP5 in the chain from com.mapr.db-maprdb that sbt was not able to find
 )
 
 assemblyMergeStrategy in assembly := {

--- a/src/main/scala/com/github/anicolaspp/spark/sql/MapRDBDataSourceReader.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/MapRDBDataSourceReader.scala
@@ -6,6 +6,7 @@ import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.sources.v2.reader.{DataReaderFactory, DataSourceReader, SupportsPushDownFilters, SupportsPushDownRequiredColumns}
 import org.apache.spark.sql.types.StructType
+import com.mapr.db.spark.MapRDBSpark
 
 class MapRDBDataSourceReader(schema: StructType, tablePath: String)
   extends DataSourceReader
@@ -23,8 +24,10 @@ class MapRDBDataSourceReader(schema: StructType, tablePath: String)
     case Some(fieldsToProject) => fieldsToProject
   }
 
-  override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
-    List(new MapRDBDataReaderFactory(tablePath, supportedFilters, readSchema()))
+  override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] = {
+    com.mapr.db.MapRDB.getTable(tablePath).getTabletInfos
+      .map(descriptor => new MapRDBDataReaderFactory(tablePath, supportedFilters, readSchema(), descriptor)).toList
+  }
 
   override def pushFilters(filters: Array[Filter]): Array[Filter] = {
     

--- a/src/main/scala/com/github/anicolaspp/spark/sql/QueryConditionBuilder.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/QueryConditionBuilder.scala
@@ -8,7 +8,7 @@ object QueryConditionBuilder extends Logging {
 
   import collection.JavaConversions._
 
-  def buildQueryConditionFrom(filters: List[Filter], tabletCondition: QueryCondition)(implicit connection: Connection): QueryCondition = createFilterCondition(filters,tabletCondition)
+  def buildQueryConditionFrom(filters: List[Filter])(implicit connection: Connection): QueryCondition = createFilterCondition(filters)
 
   /**
     * Spark sends individual filters down that we need to concat using AND. This function evaluates each filter
@@ -18,10 +18,10 @@ object QueryConditionBuilder extends Logging {
     * @param connection
     * @return
     */
-  private def createFilterCondition(filters: List[Filter],tabletCondition: QueryCondition)(implicit connection: Connection): QueryCondition = {
+  private def createFilterCondition(filters: List[Filter])(implicit connection: Connection): QueryCondition = {
     log.trace(s"FILTERS TO PUSH DOWN: $filters")
 
-    val andCondition = connection.newCondition().and().condition(tabletCondition)
+    val andCondition = connection.newCondition().and()
 
     val finalCondition = filters
       .foldLeft(andCondition) { (partialCondition, filter) => partialCondition.condition(evalFilter(filter)) }

--- a/src/main/scala/com/github/anicolaspp/spark/sql/QueryConditionBuilder.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/QueryConditionBuilder.scala
@@ -8,7 +8,7 @@ object QueryConditionBuilder extends Logging {
 
   import collection.JavaConversions._
 
-  def buildQueryConditionFrom(filters: List[Filter])(implicit connection: Connection): QueryCondition = createFilterCondition(filters)
+  def buildQueryConditionFrom(filters: List[Filter], tabletCondition: QueryCondition)(implicit connection: Connection): QueryCondition = createFilterCondition(filters,tabletCondition)
 
   /**
     * Spark sends individual filters down that we need to concat using AND. This function evaluates each filter
@@ -18,10 +18,10 @@ object QueryConditionBuilder extends Logging {
     * @param connection
     * @return
     */
-  private def createFilterCondition(filters: List[Filter])(implicit connection: Connection): QueryCondition = {
+  private def createFilterCondition(filters: List[Filter],tabletCondition: QueryCondition)(implicit connection: Connection): QueryCondition = {
     log.trace(s"FILTERS TO PUSH DOWN: $filters")
 
-    val andCondition = connection.newCondition().and()
+    val andCondition = connection.newCondition().and().condition(tabletCondition)
 
     val finalCondition = filters
       .foldLeft(andCondition) { (partialCondition, filter) => partialCondition.condition(evalFilter(filter)) }


### PR DESCRIPTION
Initial additions to enable parallelizing reading the MapRDB table.
Parallelizes only based on the number and location of tablets not on actual data sizes.
Could do with improving the way that the information is passed through to the ReaderFactories - would be nice to throw in all the information about the tablet instead of just the location and filter string