### PR TITLE
Datatype support

### DIFF
--- a/src/main/scala/com/github/anicolaspp/spark/sql/MapRDBDataReaderFactory.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/MapRDBDataReaderFactory.scala
@@ -6,6 +6,9 @@ import org.apache.spark.sql.sources._
 import org.apache.spark.sql.sources.v2.reader.{DataReader, DataReaderFactory}
 import org.apache.spark.sql.types._
 import org.ojai.store.Query
+import org.ojai.{Value,Document}
+import org.ojai.types._
+import collection.JavaConverters._
 
 /**
   * Reads data from one particular MapR-DB tablet / region
@@ -77,7 +80,7 @@ class MapRDBDataReaderFactory(table: String,
       log.debug(document.asJsonString())
 
       val values = schema.fields
-        .foldLeft(List.empty[Any])((xs, field) => document.get(field) :: xs)
+        .foldLeft(List.empty[Any])((xs, field) => getField(document,field) :: xs)
         .reverse
 
       Row.fromSeq(values)
@@ -86,6 +89,47 @@ class MapRDBDataReaderFactory(table: String,
     override def close(): Unit = {
       store.close()
       connection.close()
+    }
+
+    private def createMap(map: java.util.Map[String,Object]): Row = {
+      val scalaMap = map.asScala
+      val values = scalaMap.keySet
+        .foldLeft(List.empty[Any])((xs, field) => getValue(scalaMap(field)) :: xs)
+        .reverse
+      Row.fromSeq(values)
+    }
+
+    private def getValue(value: Any): Any = {
+      value match {
+        case v: OTimestamp => new java.sql.Timestamp(v.getMilliSecond)
+        case v: OTime => new java.sql.Timestamp(v.getMilliSecond)
+        case v: ODate => v.toDate
+        case v: java.util.Map[String,Object] => createMap(v)
+        case v: Any => v
+      }
+    }
+
+    private def getField(doc: Document, field: StructField): Any = {
+      val value = doc.getValue(field.name)
+      value.getType match {
+        case Value.Type.ARRAY => value.getList.toArray //TODO: handle array of maps/OJAI types
+        case Value.Type.BINARY => value.getBinary
+        case Value.Type.BOOLEAN => value.getBoolean
+        case Value.Type.BYTE => value.getByte
+        case Value.Type.DATE => value.getDate.toDate
+        case Value.Type.DECIMAL => value.getDecimal
+        case Value.Type.DOUBLE => value.getDouble
+        case Value.Type.FLOAT => value.getFloat
+        case Value.Type.INT => value.getInt
+        case Value.Type.INTERVAL => null//TODO: Find the actual type that corresponds to this
+        case Value.Type.LONG => value.getLong
+        case Value.Type.MAP => createMap(value.getMap)
+        case Value.Type.NULL => null
+        case Value.Type.SHORT => value.getShort
+        case Value.Type.STRING => value.getString
+        case Value.Type.TIME => new java.sql.Timestamp(value.getTime.getMilliSecond)
+        case Value.Type.TIMESTAMP => new java.sql.Timestamp(value.getTimestamp.getMilliSecond)
+      }
     }
   }
 


### PR DESCRIPTION
Arrays still need to be implemented correctly. Right now they only support basic types(no timestamps, maps, or arrays of arrays)

The following spark script is what I am using to test this:
```
/**
 * mapr dbshell commands
create /tmp/fullTest
insert /tmp/fullTest --value '{"_id":"001", "time":{"$date":"1990-01-01T00:01:20.000Z"}, "int":{"$numberInt":10},"arr":["str1","str2"], "arrInt":[10,20],"map":{"str":"hello","int":{"$numberInt":20},"ts":{"$date":"1990-01-01T00:01:20.000Z"}}}'
*/ 

import com.github.anicolaspp.spark.sql._
import org.apache.spark.sql.types._
import org.apache.spark.sql.functions._
import com.mapr.db.spark.sql._
import org.apache.spark.sql.DataFrame
import org.ojai.store._
import org.ojai.{Document,Value}

def ldf(path: String, schema:StructType) : DataFrame = {
      spark
        .read
        .format("com.github.anicolaspp.spark.sql.Reader")
        .schema(schema)
        .load(path)
        }   


val table = "/tmp/fullTest"
val schema = StructType(Seq(StructField("_id",StringType,true), StructField("arr",ArrayType(StringType,true),true), StructField("arrInt",ArrayType(DoubleType,true),true), StructField("int",IntegerType,true), StructField("map",StructType(Seq(StructField("int",IntegerType,true), StructField("str",StringType,true), StructField("ts",TimestampType,true), StructField("time",TimestampType,true))))))

val dfNormal =  spark.loadFromMapRDB(table)
dfNormal.show(false)

val dfNew2 = ldf(table,dfNormal.schema)
dfNew2.show(false)
```