### PR TITLE
Adding Support for multi tablet readers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,9 +75,7 @@ lazy val maprdbconnector = project.in(file("."))
 
       "com.mapr.db" % "maprdb-spark" % "2.3.1-mapr-1808" % "provided",
       "com.mapr.db" % "maprdb" % "6.1.0-mapr" % "provided",
-      "xerces" % "xercesImpl" % "2.11.0" % "provided",
-
-      "com.google.guava" % "guava" % "7.1-jre"
+      "xerces" % "xercesImpl" % "2.11.0" % "provided"
     )
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,9 @@ lazy val maprdbconnector = project.in(file("."))
 
       "com.mapr.db" % "maprdb-spark" % "2.3.1-mapr-1808" % "provided",
       "com.mapr.db" % "maprdb" % "6.1.0-mapr" % "provided",
-      "xerces" % "xercesImpl" % "2.11.0" % "provided"
+      "xerces" % "xercesImpl" % "2.11.0" % "provided",
+
+      "com.google.guava" % "guava" % "7.1-jre"
     )
   )
 

--- a/src/main/scala/App.scala
+++ b/src/main/scala/App.scala
@@ -1,9 +1,11 @@
 package com.github.anicolaspp
 
 import com.github.anicolaspp.spark.sql.reading.JoinType
+import com.google.common.collect.BoundType
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
+import org.joda.time.DateTime
 
 
 // ONLY for testing
@@ -23,15 +25,31 @@ object App {
     sparkSession.conf.set("spark.sql.streaming.checkpointLocation", "/Users/nperez/check")
     sparkSession.conf.set("spark.sql.streaming.schemaInference", value = true)
 
-    sparkSession.sparkContext.setLogLevel("INFO")
+    sparkSession.sparkContext.setLogLevel(args(0))
 
     println("HERE")
 
 
-    val data = sparkSession.loadFromMapRDB("/user/mapr/tables/random_data", new StructType().add("_id", StringType))
+    val data1 = sparkSession.loadFromMapRDB("/user/mapr/tables/random_data", new StructType().add("_id", StringType))
+    val data2 = sparkSession.loadFromMapRDB("/user/mapr/tables/random_data", new StructType().add("_id", StringType), args(1).toInt)
+
+
+    println(DateTime.now())
+    println(data1.count())
+    println(DateTime.now())
+
+    println(DateTime.now())
+    println(data2.count())
+    println(DateTime.now())
+
 
     //    data.where("_id = 1000008807").show
-    data.where("_id = '1966436062'").show
+//    data.where("_id = '1966436062'").show
+    
+
+
+
+
 
 //
 //      val rdd = sparkSession.sparkContext.parallelize(1 to 1000000).map(n => Row(n.toString))

--- a/src/main/scala/com/github/anicolaspp/spark/MapRDB.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/MapRDB.scala
@@ -14,14 +14,14 @@ object MapRDB {
 
   implicit class SessionOps(sparkSession: SparkSession) {
 
-    def loadFromMapRDB(path: String, schema: StructType): DataFrame = {
+    def loadFromMapRDB(path: String, schema: StructType, many: Int = 1): DataFrame = {
       sparkSession
         .read
         .format("com.github.anicolaspp.spark.sql.reading.Reader")
         .schema(schema)
+        .option("readers", many)
         .load(path)
     }
-
   }
 
   implicit class DataFrameOps(dataFrame: DataFrame) {

--- a/src/main/scala/com/github/anicolaspp/spark/sql/reading/MapRDBDataPartitionReader.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/reading/MapRDBDataPartitionReader.scala
@@ -28,9 +28,7 @@ class MapRDBDataPartitionReader(table: String,
 
   import scala.collection.JavaConverters._
 
-
-    log.debug(filters.mkString("FILTERS: [", ", ", "]"))
-  //  log.debug(tabletInfo.queryJson)
+  log.debug(filters.mkString("FILTERS: [", ", ", "]"))
 
   log.debug(query.asJsonString())
 
@@ -62,15 +60,12 @@ class MapRDBDataPartitionReader(table: String,
 
     log.debug(s"PROJECTIONS TO PUSH DOWN: $projectionsAsString")
 
-    val query = connection
+    connection
       .newQuery()
       .where(finalQueryConditionString)
       .select(projectionsNames: _*)
       .setOptions(queryOptions)
       .build()
-
-
-    query
   }
 
   private def queryOptions =
@@ -88,7 +83,6 @@ class MapRDBDataPartitionReader(table: String,
       val document = documents.next()
 
       log.debug(document.asJsonString())
-
 
       documentToRow(MapRDBSpark.newDocument(document), schema)
     }

--- a/src/main/scala/com/github/anicolaspp/spark/sql/reading/MapRDBDataSourceMultiReader.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/reading/MapRDBDataSourceMultiReader.scala
@@ -1,0 +1,82 @@
+package com.github.anicolaspp.spark.sql.reading
+
+import java.util
+
+import com.github.anicolaspp.spark.sql.MapRDBTabletInfo
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.sources.v2.reader.DataReaderFactory
+import org.apache.spark.sql.types.StructType
+import org.ojai.store.{DocumentStore, DriverManager}
+
+import scala.util.Random
+
+class MapRDBDataSourceMultiReader(schema: StructType,
+                                  tablePath: String,
+                                  hintedIndexes: List[String],
+                                  readersPerTablet: Int)
+  extends MapRDBDataSourceReader(schema, tablePath, hintedIndexes) {
+
+  import collection.JavaConversions._
+  import scala.collection.JavaConverters._
+
+  override def createDataReaderFactories(): util.List[DataReaderFactory[Row]] =
+    if (readersPerTablet == 1) {
+      super.createDataReaderFactories()
+    } else {
+      createReaders
+    }
+
+  private def createReaders: List[MapRDBDataPartitionReader] = {
+    import com.github.anicolaspp.ojai.QueryConditionExtensions._
+
+    val connection = DriverManager.getConnection("ojai:mapr:")
+    val store: DocumentStore = connection.getStore(tablePath)
+
+    val conditions = com.mapr.db.MapRDB
+      .getTable(tablePath)
+      .getTabletInfos
+      .par
+      .flatMap { tablet =>
+        val query = connection
+          .newQuery()
+          .where(tablet.getCondition)
+          .select("_id")
+          .build()
+
+        val ids = store.find(query)
+
+        val partition = ids.asScala.toList
+
+        val partitionSize = partition.size
+
+        log.info(s"READER SIZE == $partitionSize")
+
+        partition
+          .grouped((partitionSize / readersPerTablet) + 1)
+          .filter(_.nonEmpty)
+          .map(group => (group.head.getIdString, group.last.getIdString))
+          .map { range =>
+
+            val lowerBound = connection.newCondition().field("_id") >= range._1
+            val upperBound = connection.newCondition().field("_id") <= range._2
+
+            val cond = connection
+              .newCondition()
+              .and()
+              .condition(lowerBound.build())
+              .condition(upperBound.build())
+              .close()
+              .build()
+              .asJsonString()
+
+            MapRDBTabletInfo(Random.nextInt(), tablet.getLocations, cond)
+          }
+      }
+
+    val factories = conditions.map(createReaderFactory).toList
+
+    log.info(s"CREATING ${factories.length} READERS")
+
+    factories
+  }
+}

--- a/src/main/scala/com/github/anicolaspp/spark/sql/reading/Reader.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/reading/Reader.scala
@@ -13,20 +13,19 @@ class Reader extends ReadSupportWithSchema with Logging {
 
     val tablePath = options.get("path").get()
 
-    log.debug(s"TABLE PATH BEING USED: $tablePath")
+    log.info(s"TABLE PATH BEING USED: $tablePath")
 
     val hintedIndexes = options.get("idx").orElse("").trim.split(",").toList
 
     val readersPerTablet = getNumberOfReaders(options)
 
-    if (readersPerTablet > 1) {
-      new MapRDBDataSourceReaderMultiTabletReader(schema, tablePath, hintedIndexes, readersPerTablet)
-    } else {
-      new MapRDBDataSourceReader(schema, tablePath, hintedIndexes)
-    }
+    new MapRDBDataSourceMultiReader(schema, tablePath, hintedIndexes, readersPerTablet)
   }
 
   private def getNumberOfReaders(options: DataSourceOptions): Int = Try {
-    options.get("readers").orElse("1").toInt
+    val numberOfReaders = options.get("readers").orElse("1").toInt
+
+    if (numberOfReaders < 1) 1 else numberOfReaders
+
   }.getOrElse(1)
 }

--- a/src/main/scala/com/github/anicolaspp/spark/sql/reading/Reader.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/reading/Reader.scala
@@ -5,6 +5,8 @@ import org.apache.spark.sql.sources.v2.reader._
 import org.apache.spark.sql.sources.v2.{DataSourceOptions, ReadSupportWithSchema}
 import org.apache.spark.sql.types.StructType
 
+import scala.util.Try
+
 class Reader extends ReadSupportWithSchema with Logging {
 
   override def createReader(schema: StructType, options: DataSourceOptions): DataSourceReader = {
@@ -15,6 +17,16 @@ class Reader extends ReadSupportWithSchema with Logging {
 
     val hintedIndexes = options.get("idx").orElse("").trim.split(",").toList
 
-    new MapRDBDataSourceReader(schema, tablePath, hintedIndexes)
+    val readersPerTablet = getNumberOfReaders(options)
+
+    if (readersPerTablet > 1) {
+      new MapRDBDataSourceReaderMultiTabletReader(schema, tablePath, hintedIndexes, readersPerTablet)
+    } else {
+      new MapRDBDataSourceReader(schema, tablePath, hintedIndexes)
+    }
   }
+
+  private def getNumberOfReaders(options: DataSourceOptions): Int = Try {
+    options.get("readers").orElse("1").toInt
+  }.getOrElse(1)
 }

--- a/src/main/scala/com/github/anicolaspp/spark/sql/reading/SupportedFilterTypes.scala
+++ b/src/main/scala/com/github/anicolaspp/spark/sql/reading/SupportedFilterTypes.scala
@@ -1,0 +1,20 @@
+package com.github.anicolaspp.spark.sql.reading
+
+import java.sql.Timestamp
+
+object SupportedFilterTypes {
+
+  private lazy val supportedTypes = List[Class[_]](
+    classOf[Double],
+    classOf[Float],
+    classOf[Int],
+    classOf[Long],
+    classOf[Short],
+    classOf[String],
+    classOf[Timestamp],
+    classOf[Boolean],
+    classOf[Byte]
+  )
+
+  def isSupportedType(value: Any): Boolean = supportedTypes.contains(value.getClass)
+}


### PR DESCRIPTION
- We can specify how many readers we want per tablet. The default is one. Performance wise, it seems to behave better that ONLY when each reader 100K records per reader. ONLY use this feature for really large tables.